### PR TITLE
Add Yt-Browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@
 - [GNOME Twitch](http://gnome-twitch.vinszent.com/) is a Twitch GTK/GNOME client.
 - [Haguichi](https://www.haguichi.net/) is a graphical frontend for Hamachi on Linux.
 - [Transmission Remote GNOME](https://github.com/TingPing/transmission-remote-gnome) is a remote client for the Transmission torrent daemon.
+- [Yt-Browser](https://github.com/juanfgs/yt-browser) is a GTK3 interface for youtube-dl.
 
 ### Documents
 


### PR DESCRIPTION
Yt-Browser is a GTK3 interface for youtube-dl. It propose .deb and .rpm packages. I've tested it and it works well on my distro (Ubuntu 17.04 64bit), even if it's obviously in a pretty early state. 

I would be interested to get some opinion about if it's work well or not for you, and if it's enough stable to be added on the list :)