### PR TITLE
Corrected typo and removed link that was not being rendered

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,11 +224,11 @@
 - [`@gnome` on Twitter](https://twitter.com/gnome)
 - [`@gnome` on GNU Social](https://quitter.no/gnome)
 - [`GNOMEDesktop` on Youtube](https://www.youtube.com/user/GNOMEDesktop)
-- [`#gnome` on GIMPNet](irc://irc.gnome.org/gnome) - General-purpose GNOME irc channel ([complete list of channels](https://wiki.gnome.org/Community/GettingInTouch/IRC))
+- `#gnome` on GIMPNet - General-purpose GNOME IRC channel ([complete list of channels](https://wiki.gnome.org/Community/GettingInTouch/IRC))
 - [GNOME Wiki](https://wiki.gnome.org/)
 - [`@GNOMEDesktop` on Facebook](https://www.facebook.com/GNOMEDesktop)
 - [GNOME on Google+](https://plus.google.com/+gnome)
-- [Planet GNOME](http://planet.gnome.org/) - Federation of GNOME Developpers' blogs
+- [Planet GNOME](http://planet.gnome.org/) - Federation of GNOME Developers' blogs
 
 ## Developer Tools
 


### PR DESCRIPTION
The IRC link wasn't being rendered. I suspect that this is because an IRC link isn't recognized by Markdown but I am not sure.