### PR TITLE
Add cursors (ComixCursors, Bibata and Capitaine Cursors), Vimix GTK theme and Time ++ extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
   - [IDE](#ide)
   - [Libraries and Utility](#libraries-and-utility)
   - [Examples](#examples)
-  - [Documentation](#documentation)
+  - [Documentation](#documentations)
 
 ---
 
@@ -182,7 +182,7 @@
 
 - [Materia](https://github.com/nana-4/materia-theme) - Material Design-like theme for GNOME/GTK+ based desktop environments. (GTK, Shell)
 - [Adapta](https://github.com/adapta-project/adapta-gtk-theme) - Adaptive GTK+ theme based on Material Design Guidelines. (GTK, Shell)
-- [Vimix](https://github.com/vinceliuice/vimix-gtk-themes)
+- [Vimix](https://github.com/vinceliuice/vimix-gtk-themes) - A flat Material Design theme for GTK 3, GTK 2 and Gnome-Shell.
 
 ### Flat
 
@@ -198,11 +198,6 @@
 - [Vertex](https://github.com/horst3180/Vertex-theme) - Metallic theme created by horst3180, the creator of Arc. (GTK, Shell)
 - [GNOME OSX](https://github.com/paullinuxthemer/Gnome-OSX) - Theme that mimics the look and feel of macOS. (GTK, Shell)
 - [Zukitwo](https://github.com/lassekongo83/zuki-themes) - Skeumorphic grey theme, part of the zuki-theme suite. (GTK, works with Zuki-Shell for the shell theme).
-
-### Cursors
- - [ComixCursors](https://www.gnome-look.org/p/999996/)
- - [Bibata](https://www.gnome-look.org/p/1197198/)
- - [Capitaine Cursors](https://github.com/keeferrourke/capitaine-cursors)
 
 ## Icons
 
@@ -226,6 +221,11 @@
 ### Skeumorphic
 
 - [Elementary XFCE](https://github.com/shimmerproject/elementary-xfce) - Desktop-agnostic version of the icons of elementary OS.
+
+### Cursors
+ - [ComixCursors](https://www.gnome-look.org/p/999996/) - X11 mouse theme with a comics feeling. Available in six colors and three variants (regular, slim and opaque).
+ - [Bibata](https://github.com/KaizIqbal/Bibata_Cursor) - Silm material-based cursor theme.
+ - [Capitaine Cursors](https://github.com/keeferrourke/capitaine-cursors) - An x-cursor theme inspired by macOS and based on KDE Breeze. Designed to be paired with La Capitaine icons.
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@
 
 - [Materia](https://github.com/nana-4/materia-theme) - Material Design-like theme for GNOME/GTK+ based desktop environments. (GTK, Shell)
 - [Adapta](https://github.com/adapta-project/adapta-gtk-theme) - Adaptive GTK+ theme based on Material Design Guidelines. (GTK, Shell)
+- [Vimix](https://github.com/vinceliuice/vimix-gtk-themes)
 
 ### Flat
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@
 - [Emoji Selector](https://github.com/Maestroschan/emoji-selector-for-gnome) - Emoji picker applet.
 - [Media Player Indicator](https://github.com/JasonLG1979/gnome-shell-extensions-mediaplayer) - Advanced MPRIS applet for GNOME.
 - [Todo.txt](https://extensions.gnome.org/extension/570/todotxt/) - GNOME Shell interface for todo.txt.
+- [Time ++](https://extensions.gnome.org/extension/1238/time/) - A todo.txt manager, time tracker, timer, stopwatch, pomodoro, and alarm clock.
 - [MConnect](https://github.com/andyholmes/gnome-shell-extension-mconnect) - KDE Connect/MConnect integration for Gnome Shell
 - [Docker Integration](https://github.com/gpouilloux/gnome-shell-extension-docker) - An extension for managing docker containers
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
   - [Flat Icons](#flat-icons)
   - [Homogeneous Icons](#homogeneous-icons)
   - [Skeumorphic](#skeumorphic)
+  - [Cursors](#cursors)
 - [Community](#community)
 - [Developer Tools](#developer-tools)
   - [IDE](#ide)
@@ -196,6 +197,11 @@
 - [Vertex](https://github.com/horst3180/Vertex-theme) - Metallic theme created by horst3180, the creator of Arc. (GTK, Shell)
 - [GNOME OSX](https://github.com/paullinuxthemer/Gnome-OSX) - Theme that mimics the look and feel of macOS. (GTK, Shell)
 - [Zukitwo](https://github.com/lassekongo83/zuki-themes) - Skeumorphic grey theme, part of the zuki-theme suite. (GTK, works with Zuki-Shell for the shell theme).
+
+### Cursors
+ - [ComixCursors](https://www.gnome-look.org/p/999996/)
+ - [Bibata](https://www.gnome-look.org/p/1197198/)
+ - [Capitaine Cursors](https://github.com/keeferrourke/capitaine-cursors)
 
 ## Icons
 


### PR DESCRIPTION
I've added Vimix themes in Themes, Time ++ extension in Extensions#Applets, a cursors section in Icons and the relevant descriptions.