### PR TITLE
Pixel Saver is unmaintained; replace with No Title Bar (fork)

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@
 ### Windows
 - [Window Corner Preview](https://github.com/medenagan/window-corner-preview) - Create and anchor preview of a window to a corener of the screen.
 - [Cascade Windows](https://extensions.gnome.org/extension/1240/cascade-windows/) - Quickly arrange windows in a cascade.
-- [Pixel Saver](https://github.com/deadalnix/pixel-saver) - Merges the activity bar and the title bar of maximized windows.
+- [No Title Bar](https://extensions.gnome.org/extension/1267/no-title-bar/) - Merges the activity bar and the title bar of maximized windows.
 - [gTile](https://github.com/vibou/vibou.gTile) - Brings more advanced tiling to GNOME Shell.
 - [Shellshape](http://gfxmonk.net/shellshape/) - Tiling window extension for GNOME Shell.
 


### PR DESCRIPTION
The [Pixel Saver](https://extensions.gnome.org/extension/723/pixel-saver/) extension is unmaintained as the last updated version was for 3.22, a more updated fork of this extension by Fran Glais called [No Title Bar](https://extensions.gnome.org/extension/1267/no-title-bar/) is available which is updated for the latest version 3.26.