### PR TITLE
Updating GNOME OSX theme link

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@
 
 - [Greybird](https://github.com/shimmerproject/Greybird/) - Official Xubuntu theme. (GTK)
 - [Vertex](https://github.com/horst3180/Vertex-theme) - Metallic theme created by horst3180, the creator of Arc. (GTK, Shell)
-- [GNOME OSX](https://github.com/paullinuxthemer/Gnome-OSX) - Theme that mimics the look and feel of macOS. (GTK, Shell)
+- [GNOME OSC](https://github.com/paullinuxthemer/gnome-osc-themes) - Theme that mimics the look and feel of macOS. (GTK, Shell)
 - [Zukitwo](https://github.com/lassekongo83/zuki-themes) - Skeumorphic grey theme, part of the zuki-theme suite. (GTK, works with Zuki-Shell for the shell theme).
 
 ## Icons


### PR DESCRIPTION
The GNOME OSX theme changed its name to GNOME OSC (for copyright reasons, I suppose) and moved to a new repository.

Actually, the project is now a collection of different themes. I'm not sure if they can all be part of the "metallic" category. I will update the PR if necessary.