### PR TITLE
Removed links to Google+

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,8 +229,6 @@
 - [`#gnome` on GIMPNet](https://kiwiirc.com/client/irc.gnome.org#gnome) - General-purpose GNOME IRC channel ([complete list of channels](https://wiki.gnome.org/Community/GettingInTouch/IRC))
 - [GNOME Wiki](https://wiki.gnome.org/)
 - [`@GNOMEDesktop` on Facebook](https://www.facebook.com/GNOMEDesktop)
-- [`GNOME` on Google+](https://plus.google.com/+gnome)
-- [GNOME Community on Google+](https://plus.google.com/communities/104680683972837006235)
 
 ## Developer Tools
 


### PR DESCRIPTION
Google+ is shutting down on April 2nd, 2019 and these links would then be redundant. Can be merged right away or after the shutdown in 2 days.