### PR TITLE
Update link to GJS docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@
 - [GNOME Newcomers Wiki](https://wiki.gnome.org/Newcomers/) - Perfect place to start contributing to GNOME.
 - [GNOME Developer Center](https://developer.gnome.org/) - Contains all the official GNOME documentations.
 - [Valadoc](https://valadoc.org/) - Documentation about Vala.
-- [GJS Documentation](http://devdocs.baznga.org/) - Documentation for the JavaScript GTK bindings.
+- [GJS Documentation](https://gjs-docs.gnome.org/) - Documentation for the JavaScript GTK bindings.
 - [The Python GTK+ 3 Tutorial](https://python-gtk-3-tutorial.readthedocs.io/en/latest/) - Introduction to writing GTK+ 3 applications in Python.
 
 [GNOME Core]: https://cdn.rawgit.com/kazhnuz/awesome-gnome/master/images/gnome-icon-symbolic.svg


### PR DESCRIPTION
The old link is dead. GJS docs are now hosted on https://gjs-docs.gnome.org/.