### PR TITLE
Add Flatseal

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@
 - [Dynamic Gnome Wallpapers](https://github.com/manishprivet/dynamic-gnome-wallpapers) - Gallery of MacOS like dynamic wallpapers, and easy scripts to install them
 - [GDM Settings](https://gdm-settings.github.io) - A settings app for GDM (GNOME's Login Screen a.k.a GNOME Display Manager).
 - [AdwSteamGtk](https://github.com/Foldex/AdwSteamGtk) - [Adwaita for Steam](https://github.com/tkashkin/Adwaita-for-Steam) skin installer.
+- [Flatseal](https://github.com/tchx84/Flatseal) - Flatpak permission manager.
 
 ### Utilities
 


### PR DESCRIPTION
Add [Flatseal](https://github.com/tchx84/Flatseal), a Flatpak permission manager powered by GTK 4 and Libadwaita.