### PR TITLE
Add GNOME Circle mark to Cartdridges

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@
 
 - [Lutris](https://github.com/lutris/lutris) - Open Source gaming platform.
 - [GNOME Games](https://wiki.gnome.org/Apps/Games) - Game launcher and an emulation frontend to libretro.
-- [Cartridges](https://github.com/kra-mo/cartridges) - Game launcher with Steam, Lutris, Heroic, Bottles and itch library import.
+- [Cartridges](https://github.com/kra-mo/cartridges) - Game launcher with Steam, Lutris, Heroic, Bottles and itch library import. ![GNOME Circle][GNOME Circle]
 
 ### System and Customization
 


### PR DESCRIPTION
Simply add the GNOME Circle mark to Cartdridges which [has been added to the list](https://thisweek.gnome.org/posts/2023/05/twig-97/).