### PR TITLE
Add Parabolic

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@
 - [Feeds](https://gitlab.gnome.org/World/gfeeds) - An RSS/Atom feed reader.
 - [Cawbird](https://ibboard.co.uk/cawbird/) - Twitter client.
 - [Haguichi](https://www.haguichi.net/) - Graphical frontend for Hamachi.
+- [Parabolic](https://github.com/NickvisionApps/Parabolic) - `yt-dlp` graphical fronted.
 
 ### Office
 


### PR DESCRIPTION
[Parabolic](https://github.com/NickvisionApps/Parabolic) is a graphical front-end of `yt-dlp` for downloading audio and video.