### PR TITLE
Add Turtle

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@
 - [Sysprof](https://apps.gnome.org/app/org.gnome.Sysprof/) - Profile an application or entire system.
 - [DevHelp](https://apps.gnome.org/app/org.gnome.Devhelp/) - Developer tool for browsing and searching API documentation.
 - [Escambo](https://github.com/CleoMenezesJr/escambo) - HTTP-based APIs test application.
+- [Turtle](https://gitlab.gnome.org/philippun1/turtle) - Tool to manage Git repositories within Nautilus by providing emblems and context menus.
 
 #### Design Tooling
 


### PR DESCRIPTION
Add Turtle, which has been feature in [TWIG 109](https://thisweek.gnome.org/posts/2023/08/twig-109/#turtle).

> [Turtle](https://gitlab.gnome.org/philippun1/turtle) is a tool to manage git repositories within Nautilus by providing emblems and context menus. For more complex operations it provides specific dialogs, i.e. commit, sync, log, settings, etc.