### PR TITLE
Add Forge Sparks

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@
 - [Sysprof](https://apps.gnome.org/app/org.gnome.Sysprof/) - Profile an application or entire system.
 - [DevHelp](https://apps.gnome.org/app/org.gnome.Devhelp/) - Developer tool for browsing and searching API documentation.
 - [Escambo](https://github.com/CleoMenezesJr/escambo) - HTTP-based APIs test application.
+- [Forge Sparks](https://github.com/rafaelmardojai/forge-sparks) - Git forge (GitHub, Gitea, Forgejo) desktop notification application. ![GNOME Circle][GNOME Circle]
 
 #### Design Tooling
 


### PR DESCRIPTION
Add Forge Sparks, an application recently accepted into GNOME Circle, that provides Git forges notifications on your desktop.