### PR TITLE
Add Planify

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@
 - [Timetrack](https://gitlab.gnome.org/danigm/timetrack) - Time tracker.
 - [Teleprompter](https://github.com/Nokse22/teleprompter) - Simple application to read scrolling text from your screen.
 - [Errands](https://github.com/mrvladus/Errands) - Todo application for those who prefer simplicity. ![GNOME Circle][GNOME Circle]
+- [Planify](https://github.com/alainm23/planify) - Project and task manager with Todoist support.
 
 ### Well Being
 


### PR DESCRIPTION
Add [Planify](https://github.com/alainm23/planify), a project and task manager recently ported to `libadwaita`.