### PR TITLE
Add Prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,8 @@
 - [GDM Settings](https://gdm-settings.github.io) - A settings app for GDM (GNOME's Login Screen a.k.a GNOME Display Manager).
 - [AdwSteamGtk](https://github.com/Foldex/AdwSteamGtk) - [Adwaita for Steam](https://github.com/tkashkin/Adwaita-for-Steam) skin installer.
 - [Flatseal](https://github.com/tchx84/Flatseal) - Flatpak permission manager.
-- [Mission Center](https://missioncenter.io/) - Monitor your CPU, Memory, Disk, Network and GPU usage
+- [Mission Center](https://missioncenter.io/) - Monitor your CPU, Memory, Disk, Network and GPU usage.
+- [Prompt](https://gitlab.gnome.org/chergert/prompt) - Terminal with first-class support for containers.
 
 ### Utilities
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@
 - [Bottles](https://github.com/bottlesdevs/Bottles) - Wine environments manager to run Windows software and games.
 - [BoxBuddy](https://github.com/Dvlv/BoxBuddyRS) - Graphical Distrobox manager.
 - [Pods](https://github.com/marhkb/pods) - Podman containers manager.
-- [Prompt](https://gitlab.gnome.org/chergert/prompt) - Terminal with first-class support for containers.
+- [Ptyxis](https://gitlab.gnome.org/chergert/ptyxis) - Terminal with first-class support for containers.
 
 ### Utilities
 


### PR DESCRIPTION
Add [Prompt](https://gitlab.gnome.org/chergert/prompt), a terminal with first-class support for containerized environments.