### PR TITLE
Add Obsidian Adwaita Theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,10 @@
  - [Bibata](https://github.com/KaizIqbal/Bibata_Cursor) - Silm material-based cursor theme.
  - [Capitaine Cursors](https://github.com/keeferrourke/capitaine-cursors) - An x-cursor theme inspired by macOS and based on KDE Breeze. Designed to be paired with La Capitaine icons.
 
+### Themes for non-GTK apps
+
+- [Obsidian Adwaita Theme](https://github.com/birneee/obsidian-adwaita-theme) - [Obsidian](https://obsidian.md) theme in the style of GNOME Adwaita.
+
 ## Community
 
 ### Official Venues


### PR DESCRIPTION
Add subsection, Themes for non-GTK apps, in the Look and Feel section intended for referencing themes that enable non-GNOME desktop applications to adopt the appearance of `libadwaita`. Let me know if this falls within the repository's scope. I've started it with a theme for Obsidian, but I have other themes in mind that could be added, including the Adwaita skin for Steam, which is already mentioned in the list.