### PR TITLE
Move Firefox GNOME Theme to Themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,6 @@
 
 ## Third-party Apps Plugins
 
-- [Firefox GNOME Theme](https://github.com/rafaelmardojai/firefox-gnome-theme) - Integrate Firefox into GNOME-based desktop using Adwaita.
 - [Nautilus Terminal](https://github.com/flozz/nautilus-terminal) - Integrates a terminal into Nautilus.
 
 ## Extensions
@@ -300,6 +299,7 @@
 
 ### Themes for non-GTK apps
 
+- [Firefox GNOME Theme](https://github.com/rafaelmardojai/firefox-gnome-theme) - Integrate Firefox into GNOME-based desktop using Adwaita.
 - [Obsidian Adwaita Theme](https://github.com/birneee/obsidian-adwaita-theme) - [Obsidian](https://obsidian.md) theme in the style of GNOME Adwaita.
 
 ## Community


### PR DESCRIPTION
Following #160, move Firefox GNOME Theme to the new "Theme for non-GTK apps" section.