### PR TITLE
Add Biblioteca

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@
 - [Escambo](https://github.com/CleoMenezesJr/escambo) - HTTP-based APIs test application.
 - [Forge Sparks](https://github.com/rafaelmardojai/forge-sparks) - Git forge (GitHub, Gitea, Forgejo) desktop notification application. ![GNOME Circle][GNOME Circle]
 - [Turtle](https://gitlab.gnome.org/philippun1/turtle) - Tool to manage Git repositories within Nautilus by providing emblems and context menus.
+- [Biblioteca](https://github.com/workbenchdev/Biblioteca) - GNOME documentation (offline) reader with fuzzy search, dark mode and mobile support. ![GNOME Circle][GNOME Circle]
 
 #### Design Tooling
 


### PR DESCRIPTION
Add [Biblioteca](https://github.com/workbenchdev/Biblioteca), a GNOME documentation reader recently added to [GNOME Circle](https://thisweek.gnome.org/posts/2024/03/twig-141/#gnome-circle-apps-and-libraries).