### PR TITLE
Add Hieroglyphic

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@
 - [Forge Sparks](https://github.com/rafaelmardojai/forge-sparks) - Git forge (GitHub, Gitea, Forgejo) desktop notification application. ![GNOME Circle][GNOME Circle]
 - [Turtle](https://gitlab.gnome.org/philippun1/turtle) - Tool to manage Git repositories within Nautilus by providing emblems and context menus.
 - [Biblioteca](https://github.com/workbenchdev/Biblioteca) - GNOME documentation (offline) reader with fuzzy search, dark mode and mobile support. ![GNOME Circle][GNOME Circle]
+- [Hieroglyphic](https://github.com/FineFindus/Hieroglyphic) - Application to search for LaTeX symbols by sketching.
 
 #### Design Tooling
 


### PR DESCRIPTION
Add [Hieroglyphic](https://github.com/FineFindus/Hieroglyphic), an application to search for LaTeX symbols by sketching. A fork of TeX Match using `libadwaita`.