### PR TITLE
Update Hieroglyphic to GNOME Circle

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@
 - [Forge Sparks](https://github.com/rafaelmardojai/forge-sparks) - Git forge (GitHub, Gitea, Forgejo) desktop notification application. ![GNOME Circle][GNOME Circle]
 - [Turtle](https://gitlab.gnome.org/philippun1/turtle) - Tool to manage Git repositories within Nautilus by providing emblems and context menus.
 - [Biblioteca](https://github.com/workbenchdev/Biblioteca) - GNOME documentation (offline) reader with fuzzy search, dark mode and mobile support. ![GNOME Circle][GNOME Circle]
-- [Hieroglyphic](https://github.com/FineFindus/Hieroglyphic) - Application to search for LaTeX symbols by sketching.
+- [Hieroglyphic](https://github.com/FineFindus/Hieroglyphic) - Application to search for LaTeX symbols by sketching. ![GNOME Circle][GNOME Circle]
 
 #### Design Tooling
 


### PR DESCRIPTION
Hieroglyphic [has been added](https://apps.gnome.org/Hieroglyphic) to GNOME Circle.