### PR TITLE
Add Damask

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@
 - [BoxBuddy](https://github.com/Dvlv/BoxBuddyRS) - Graphical Distrobox manager.
 - [Pods](https://github.com/marhkb/pods) - Podman containers manager.
 - [Ptyxis](https://gitlab.gnome.org/chergert/ptyxis) - Terminal with first-class support for containers.
+- [Damask](https://gitlab.gnome.org/subpop/damask) - Application that automatically sets wallpaper from a variety or sources (local folder, Wallhaven, Bing Wallpaper, NASA Astronomy, etc).
 
 ### Utilities
 


### PR DESCRIPTION
Add [Damask](https://gitlab.gnome.org/subpop/damask), an application (Vala/`libadwaita`) that automatically sets wallpaper from a variety or sources such as local folder, Wallhaven, Bing Wallpaper and NASA Astronomy.