### PR TITLE
[RFC] Remove old/stale elements and GTK3 apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,10 +113,7 @@
 - [Curtail](https://apps.gnome.org/en/Curtail) - Simple & useful image compressor. ![GNOME Circle][GNOME Circle]
 - [Identity](https://apps.gnome.org/Identity) - Compare image and video. ![GNOME Circle][GNOME Circle]
 - [Switcheroo](https://apps.gnome.org/Converter) - Image converter and manipulator ([ImageMagick](https://imagemagick.org) frontend). ![GNOME Circle][GNOME Circle]
-- [Drawing](https://flathub.org/apps/com.github.maoschanz.drawing) - Responsive drawing application.
 - [Coulr](https://flathub.org/apps/com.github.huluti.Coulr) - Convert between RGB and hexadecimal codes for colours.
-- [Color Picker](https://flathub.org/apps/nl.hjdskes.gcolor3) - Color picker, working on both X11 and Wayland.
-- [GThumb](https://gitlab.gnome.org/GNOME/gthumb) - Powerful and advanced application to manage your photos and images.
 - [ASCII Draw](https://flathub.org/apps/io.github.nokse22.asciidraw) - Draw graphs and more using only characters.
 - [Mingle](https://flathub.org/apps/io.github.halfmexican.Mingle) - Application to combine emojis using Google's Emoji Kitchen.
 
@@ -127,7 +124,6 @@
 
 ### Gaming
 
-- [Lutris](https://flathub.org/apps/net.lutris.Lutris) - Open Source gaming platform.
 - [Cartridges](https://apps.gnome.org/Cartridges) - Game launcher with Steam, Lutris, Heroic, Bottles and itch library import. ![GNOME Circle][GNOME Circle]
 
 ### System and Customization
@@ -135,10 +131,7 @@
 - [Pika Backup](https://apps.gnome.org/PikaBackup) - Simple backups based on borg. ![GNOME Circle][GNOME Circle]
 - [Déjà Dup Backups](https://apps.gnome.org/DejaDup) - Simple backups tool. ![GNOME Circle][GNOME Circle]
 - [GNOME Tweaks](https://gitlab.gnome.org/GNOME/gnome-tweaks) - Graphical interface for advanced GNOME settings.
-- [Tilix](https://gnunn1.github.io/tilix-web) - Tiling terminal emulator.
-- [Menulibre](https://smdavis.us/projects/menulibre) - Manage your applications categories if you use a traditional application menu like Arc or the Application Menu.
 - [HydraPaper](https://hydrapaper.gabmus.org) - Set a different background for each monitor.
-- [Dynamic Wallpaper Editor](https://flathub.org/apps/com.github.maoschanz.DynamicWallpaperEditor) - Utility for editing GNOME's XML wallpapers
 - [Dynamic Gnome Wallpapers](https://github.com/manishprivet/dynamic-gnome-wallpapers) - Gallery of MacOS like dynamic wallpapers, and easy scripts to install them
 - [GDM Settings](https://gdm-settings.github.io) - A settings app for GDM (GNOME's Login Screen a.k.a GNOME Display Manager).
 - [AdwSteamGtk](https://flathub.org/apps/io.github.Foldex.AdwSteamGtk) - [Adwaita for Steam](https://github.com/tkashkin/Adwaita-for-Steam) skin installer.
@@ -159,11 +152,6 @@
 - [Junction](https://apps.gnome.org/Junction) - Junction lets you choose the application to open files and links. ![GNOME Circle][GNOME Circle]
 - [Impression](https://flathub.org/apps/io.gitlab.adhami3310.Impression) - Bootable driver flasher application ![GNOME Circle][GNOME Circle]
 - [Kooha](https://flathub.org/apps/io.github.seadve.Kooha) - Elegantly record your screen.
-- [GPaste](https://github.com/Keruspe/GPaste) - Clipboard manager (composed of an application and a gnome-shell extension).
-- [Catfish](https://launchpad.net/catfish-search) - Simple search application.
-- [Detwinner](https://neatdecisions.com/products/detwinner-linux) - Simple and fast tool for removing duplicate files.
-- [Recipes](https://gitlab.gnome.org/GNOME/recipes) - Cooking application.
-- [Sunflower](http://sunflower-fm.org) - Small and highly customizable twin-panel file manager.
 - [Lan Mouse](https://github.com/feschber/lan-mouse) - Mouse and keyboard sharing software (software KVM switch).
 - [Moussam](https://amit9838.github.io/mousam) - Weather application with 7 days forecast from Open-Meteo.com.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@
   - [Applets](#applets)
   - [Windows](#windows)
   - [Visual Changes](#visual-changes)
-  - [Services Integration](#services-integration)
 - [Look and Feel](#look-and-feel)
   - [Icons](#icons)
   - [Cursors](#cursors)
@@ -212,7 +211,6 @@
 
 - [Just Perfection](https://extensions.gnome.org/extension/3843/just-perfection) - Customize GNOME Shell.
 - [Custom Hot Corners - Extended](https://extensions.gnome.org/extension/4167/custom-hot-corners-extended) - Customize hot corners.
-- [Extensions Sync](https://extensions.gnome.org/extension/1486/extensions-sync) - Syncs gnome shell keybindings, tweaks settings and extensions with their configuration across all gnome installations.
 - [Quick Settings Tweaker](https://extensions.gnome.org/extension/5446/quick-settings-tweaker) - Tweak your quick settings menu.
 
 ### Menus
@@ -224,39 +222,27 @@
 
 ### Applets
 
-- [RunCat](https://github.com/win0err/gnome-runcat) — The cat tells you the CPU usage by running speed.
+- [RunCat](https://extensions.gnome.org/extension/2986/runcat/) — The cat tells you the CPU usage by running speed.
 - [Caffeine](https://extensions.gnome.org/extension/517/caffeine) - Applet that let you deactivate the GNOME lock screen.
 - [Removable Drive Menu](https://extensions.gnome.org/extension/7/removable-drive-menu) - Status menu to show your removable drives.
-- [OpenWeather](https://extensions.gnome.org/extension/750/openweather) - Weather applet.
+- [OpenWeather](https://extensions.gnome.org/extension/6655/openweather/) - Weather applet.
 - [Clipboard Indicator](https://extensions.gnome.org/extension/779/clipboard-indicator) - Simple clipboard applet.
-- [Desk Changer](https://extensions.gnome.org/extension/1131/desk-changer) - Wallpaper slideshow applet.
-- [Emoji Selector](https://extensions.gnome.org/extension/1162/emoji-selector) - Emoji picker applet.
 - [Todo.txt](https://extensions.gnome.org/extension/570/todotxt) - Interface for todo.txt.
-- [Time ++](https://extensions.gnome.org/extension/1238/time) - A todo.txt manager, time tracker, timer, stopwatch, pomodoro, and alarm clock.
 - [GSConnect](https://extensions.gnome.org/extension/1319/gsconnect) - KDE Connect implementation.
 - [KStatusNotifiers/AppIndicator Support](https://extensions.gnome.org/extension/615/appindicator-support) - Appindicator systray.
 
 ### Windows
 
-- [PaperWM](https://github.com/paperwm/PaperWM) - Tiled scrollable window management.
-- [Coverflow Alt-Tab](https://github.com/dmo60/CoverflowAltTab) - Advanced fullscreen app switcher.
-
-### Audio
-
-- [Application Volume Mixer](https://github.com/mymindstorm/gnome-volume-mixer) - Control volume output per-application.
+- [PaperWM](https://extensions.gnome.org/extension/6099/paperwm/) - Tiled scrollable window management.
+- [Coverflow Alt-Tab](https://extensions.gnome.org/extension/97/coverflow-alt-tab/) - Advanced fullscreen app switcher.
 
 ### Visual Changes
 
-- [Blur-my-shell](https://github.com/aunetx/blur-my-shell) - Apply a blur effect to the overview and top panel background.
-- [Transparent Shell](https://github.com/Siroj42/gnome-extension-transparent-shell) - Makes some UI elements transparent.
+- [Blur-my-shell](https://extensions.gnome.org/extension/3193/blur-my-shell/) - Apply a blur effect to the overview and top panel background.
 - [Compiz windows effect](https://extensions.gnome.org/extension/3210/compiz-windows-effect) - Adds wobbly effects to windows.
 - [Useless Gaps](https://extensions.gnome.org/extension/4684/useless-gaps) - For aesthetic purposes adds useless gaps around tiled and maximized windows.
-- [Desktop Cube](https://github.com/Schneegans/Desktop-Cube) - A Desktop Cube for GNOME Shell
-- [Burn My Windows](https://github.com/Schneegans/Burn-My-Windows) - Open/Close your windows with style.
-
-### Services integration
-
-- [GMail Message Tray](https://github.com/shumingch/GmailMessageTray) - Integrate GMail with your desktop.
+- [Desktop Cube](https://extensions.gnome.org/extension/4648/desktop-cube/) - A Desktop Cube for GNOME Shell
+- [Burn My Windows](https://extensions.gnome.org/extension/4679/burn-my-windows/) - Open/Close your windows with style.
 
 ## Look and Feel
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@
 - [Warp](https://apps.gnome.org/Warp) - Fast and secure file transfer. ![GNOME Circle][GNOME Circle]
 - [Wike](https://apps.gnome.org/Wike) - Search and read Wikipedia articles. ![GNOME Circle][GNOME Circle]
 - [Feeds](https://gitlab.gnome.org/World/gfeeds) - An RSS/Atom feed reader.
+- [Haguichi](https://www.haguichi.net) - Graphical frontend for Hamachi.
 - [Parabolic](https://flathub.org/apps/org.nickvision.tubeconverter) - `yt-dlp` graphical fronted.
 - [Geopard](https://ranfdev.com/projects/geopard) - Colorful Gemini client.
 - [Fractal](https://flathub.org/apps/org.gnome.Fractal) - Matrix client.

--- a/README.md
+++ b/README.md
@@ -58,9 +58,7 @@
 - [Polari](https://apps.gnome.org/Polari) - Talk to people on IRC. ![GNOME Circle][GNOME Circle]
 - [Warp](https://apps.gnome.org/Warp) - Fast and secure file transfer. ![GNOME Circle][GNOME Circle]
 - [Wike](https://apps.gnome.org/Wike) - Search and read Wikipedia articles. ![GNOME Circle][GNOME Circle]
-- [Geary](https://gitlab.gnome.org/GNOME/geary) - Modern mail client, created originally by Yorba.
 - [Feeds](https://gitlab.gnome.org/World/gfeeds) - An RSS/Atom feed reader.
-- [Haguichi](https://www.haguichi.net) - Graphical frontend for Hamachi.
 - [Parabolic](https://flathub.org/apps/org.nickvision.tubeconverter) - `yt-dlp` graphical fronted.
 - [Geopard](https://ranfdev.com/projects/geopard) - Colorful Gemini client.
 - [Fractal](https://flathub.org/apps/org.gnome.Fractal) - Matrix client.
@@ -71,9 +69,7 @@
 - [Apostrophe](https://apps.gnome.org/Apostrophe) - Distraction-free Markdown editor. ![GNOME Circle][GNOME Circle]
 - [Citations](https://apps.gnome.org/Citations) - Manage your bibliography. ![GNOME Circle][GNOME Circle]
 - [NFO Viewer](https://flathub.org/apps/details/io.otsaloma.nfoview) - Simple viewer for NFO files, beating text editors with preset font and encoding settings and clickable hyperlink support.
-- [Paperwork](https://flathub.org/apps/work.openpaper.Paperwork) - Personal document manager for scanned documents and PDFs.
 - [Foliate](https://flathub.org/apps/com.github.johnfactotum.Foliate) - Simple and modern eBook reader.
-- [Marker](https://flathub.org/apps/com.github.fabiocolacio.marker) - Markdown editor with an integrated previewer.
 - [Paper Clip](https://flathub.org/apps/io.github.diegoivan.pdf_metadata_editor) - PDF metadata editor.
 - [RNote](https://flathub.org/apps/com.github.flxzt.rnote) - Sketch and take handwritten notes.
 
@@ -83,8 +79,6 @@
 - [Khronos](https://apps.gnome.org/Khronos) - Log the time it took to do tasks. ![GNOME Circle][GNOME Circle]
 - [Errands](https://apps.gnome.org/List) - Todo application for those who prefer simplicity. ![GNOME Circle][GNOME Circle]
 - [Endeavour](https://flathub.org/apps/details/org.gnome.Todo) - Manage your tasks.
-- [GTimeLog](https://flathub.org/apps/org.gtimelog.GTimeLog) - Simple app for keeping track of time.
-- [Gnome Pomodoro](http://gnomepomodoro.org) - Simple pomodoro timer.
 - [Timetrack](https://flathub.org/apps/net.danigm.timetrack) - Time tracker.
 - [Teleprompter](https://flathub.org/apps/io.github.nokse22.teleprompter) - Simple application to read scrolling text from your screen.
 - [Planify](https://flathub.org/apps/io.github.alainm23.planify) - Project and task manager with Todoist support.
@@ -103,12 +97,9 @@
 - [Podcasts](https://apps.gnome.org/Podcasts) - Listen to your favourite podcasts. ![GNOME Circle][GNOME Circle]
 - [Decibels](https://apps.gnome.org/Decibels) - Simple music player with waveform view. ![GNOME Circle][GNOME Circle]
 - [Cozy](https://flathub.org/apps/com.github.geigi.cozy) - Audiobook player.
-- [Vocal](https://github.com/needle-and-thread/vocal) - Powerful, beautiful, and simple podcast client for the modern free desktop.
 - [Celluloid](https://flathub.org/apps/io.github.celluloid_player.Celluloid) - Simple frontend for mpv.
-- [Lollypop](https://gitlab.gnome.org/World/lollypop) - Beautiful music application.
 - [Parlatype](http://gkarsay.github.io/parlatype) - Audio player specialized for transcription.
 - [Easy Effects](https://flathub.org/apps/com.github.wwmm.easyeffects) - Audio effects for PipeWire applications .
-- [Pitivi](http://www.pitivi.org) - Beautiful and powerful video editor.
 - [Spot](https://flathub.org/apps/dev.alextren.Spot) - Spotify Client.
 - [Clapper](https://rafostar.github.io/clapper) - Simple and modern media player.
 - [Footage](https://gitlab.com/adhami3310/Footage) - Application to trim, flip, rotate and crop individual clips.

--- a/contributing.md
+++ b/contributing.md
@@ -18,6 +18,7 @@ Ensure your pull request adheres to the following guidelines:
 - New categories or improvements to the existing categorization are welcome.
 - Please check that your contribution follows the following requirements :
   - The application has to follow enough of the GNOME HIG to work in a GNOME-based Desktop, by using an headerbar as the titlebar and looking clean in a vanilla GNOME desktop.
+  - The application has to use GTK4 and LibAdwaita
   - Please avoid unmaintained items as they could break with time.
   - Please avoid items that haven't had any stable release, aren't mature or aren't mature yet.
   - If the item you propose is a Core GNOME Project, please label it as such.


### PR DESCRIPTION
GTK4 and Libadwaita are here for several years, so remove gtk3 apps for the list. The idea is that they'll be readded once they convert to GTK4. I'm not 100% sure this is yet the time to do that, but it might be ? I mean, at a same time we remove some important apps, but it's usefull to make sure the list contain apps that are up the the current vision of GNOME (not the exact version, as they might not have every latest libadwaita widget, but they will be roughly up to standards). This is an RFC in the case people disagree with the idea.

Also remove some extensions and stuff, as we often do when they're old.

## TODO

- [x] Finish removing every gtk3 apps
- [x] Remove some staled extension
- [x] Change the rules to require gtk4 and libadwaita apps.