### PR TITLE
Add Aurea

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@
 - [DevHelp](https://apps.gnome.org/Devhelp) - Developer tool for browsing and searching API documentation.
 - [Escambo](https://github.com/CleoMenezesJr/escambo) - HTTP-based APIs test application.
 - [Turtle](https://gitlab.gnome.org/philippun1/turtle) - Tool to manage Git repositories within Nautilus by providing emblems and context menus.
+- [Aurea](https://flathub.org/apps/io.github.cleomenezesjr.aurea) - Simple preview banner made to read metainfo files from Flatpak apps and represent them as they would on Flathub. 
 
 #### Design Tooling
 


### PR DESCRIPTION
Add [Aurea](https://flathub.org/apps/io.github.cleomenezesjr.aurea) a tool to preview the FlatHub banner from Flatpak metadata file.