### PR TITLE
Add Snoop

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@
 - [Sunflower](http://sunflower-fm.org) - Small and highly customizable twin-panel file manager.
 - [Lan Mouse](https://github.com/feschber/lan-mouse) - Mouse and keyboard sharing software (software KVM switch).
 - [Moussam](https://amit9838.github.io/mousam) - Weather application with 7 days forecast from Open-Meteo.com.
+- [Snoop](https://flathub.org/apps/de.philippun1.Snoop) - Application (with Nautilus extension) to search through file contents in a given folder.
 
 ### Security and Privacy
 


### PR DESCRIPTION
Add [Snoop](https://flathub.org/apps/de.philippun1.Snoop), an application (with Nautilus extension) to search through file contents in a given folder.