### PR TITLE
Add Showtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@
 - [Collector](https://mijorus.it/projects/collector) - Dropover utility that allows to drag files/images/text into a collection window and drop them anywhere.
 - [Fotema](https://flathub.org/apps/app.fotema.Fotema) - Photo gallery with support for iOS Live Photos and Samsung Motion Photos and with map view.
 - [Drum Machine](https://apps.gnome.org/DrumMachine/) - Create and play drum beats. ![GNOME Circle][GNOME Circle]*<<<<<<< patch-1
-- [Showtime](https://gitlab.gnome.org/GNOME/Incubator/showtime) - Distraction-free video player.
+- [Showtime](https://gitlab.gnome.org/GNOME/showtime) - Distraction-free video player.
 
 ### Graphics
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@
 - [G4Music](https://flathub.org/apps/com.github.neithern.g4music) - Play your music elegantly.
 - [Monophony](https://flathub.org/fr/apps/io.gitlab.zehkira.Monophony) - Stream music from YouTube.
 - [Collector](https://mijorus.it/projects/collector) - Dropover utility that allows to drag files/images/text into a collection window and drop them anywhere.
+- [Showtime](https://gitlab.gnome.org/GNOME/Incubator/showtime) - Distraction-free video player.
 
 ### Graphics
 


### PR DESCRIPTION
Add [Showtime](https://gitlab.gnome.org/GNOME/Incubator/showtime), a distraction-free video player which has been accepted into the GNOME Incubator. I'll need to update the link and the official GNOME tag when it will be ready.
