### PR TITLE
Add Luminance

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@
 - [Pods](https://flathub.org/apps/com.github.marhkb.Pods) - Podman containers manager.
 - [Ptyxis](https://flathub.org/apps/app.devsuite.Ptyxis) - Terminal with first-class support for containers.
 - [Damask](https://gitlab.gnome.org/subpop/damask) - Application that automatically sets wallpaper from a variety or sources (local folder, Wallhaven, Bing Wallpaper, NASA Astronomy, etc).
+- [Luminance](https://github.com/sidevesh/Luminance) - Simple application to control brightness of displays (including external) supporting DDC/CI.
 
 ### Utilities
 


### PR DESCRIPTION
Add [Luminance](https://github.com/sidevesh/Luminance), a simple application to control displays brightness that just have been ported to `libadwaita`.