### PR TITLE
Add Embellish

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@
 - [Damask](https://gitlab.gnome.org/subpop/damask) - Application that automatically sets wallpaper from a variety or sources (local folder, Wallhaven, Bing Wallpaper, NASA Astronomy, etc).
 - [Luminance](https://github.com/sidevesh/Luminance) - Simple application to control brightness of displays (including external) supporting DDC/CI.
 - [Bustle](https://flathub.org/apps/org.freedesktop.Bustle) - D-Bus activity viewer that draws diagram sequences.
+- [Embellish](https://flathub.org/apps/io.github.getnf.embellish) - Application to install and manage Nerd Fonts on the system.
 
 ### Utilities
 


### PR DESCRIPTION
Add [Embellish](https://flathub.org/apps/io.github.getnf.embellish), a `libadwaita` application to install and manage Nerd Fonts on the system.