### PR TITLE
Add Fotema

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@
 - [G4Music](https://flathub.org/apps/com.github.neithern.g4music) - Play your music elegantly.
 - [Monophony](https://flathub.org/fr/apps/io.gitlab.zehkira.Monophony) - Stream music from YouTube.
 - [Collector](https://mijorus.it/projects/collector) - Dropover utility that allows to drag files/images/text into a collection window and drop them anywhere.
-- [Foliate](https://flathub.org/apps/app.fotema.Fotema) - Photo gallery with support for iOS Live Photos and Samsung Motion Photos and with map view.
+- [Fotema](https://flathub.org/apps/app.fotema.Fotema) - Photo gallery with support for iOS Live Photos and Samsung Motion Photos and with map view.
 
 ### Graphics
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@
 - [G4Music](https://flathub.org/apps/com.github.neithern.g4music) - Play your music elegantly.
 - [Monophony](https://flathub.org/fr/apps/io.gitlab.zehkira.Monophony) - Stream music from YouTube.
 - [Collector](https://mijorus.it/projects/collector) - Dropover utility that allows to drag files/images/text into a collection window and drop them anywhere.
+- [Foliate](https://flathub.org/apps/app.fotema.Fotema) - Photo gallery with support for iOS Live Photos and Samsung Motion Photos and with map view.
 
 ### Graphics
 


### PR DESCRIPTION
Add [Fotema](https://flathub.org/apps/app.fotema.Fotema), a `libadwaita` photo gallery with support for iOS Live Photos and Samsung Motion Photos and with map view.
