### PR TITLE
Add Newelle

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@
 - [Teleprompter](https://flathub.org/apps/io.github.nokse22.teleprompter) - Simple application to read scrolling text from your screen.
 - [Planify](https://flathub.org/apps/io.github.alainm23.planify) - Project and task manager with Todoist support.
 - [Time Tracker](https://flathub.org/apps/com.lynnmichaelmartin.TimeTracker) - Local-first project time tracker with sync option via cloud or network storage (CSV file).
+- [Newelle](https://github.com/qwersyk/Newelle) - Virtual assistant (local, based on GPT4All) that interacts with the system by running shell commands and execute Python code.
 
 ### Well Being
 


### PR DESCRIPTION
Add [Newelle](https://github.com/qwersyk/Newelle), a `libadwaita` virtual assistant (local, based on GPT4All) that interacts with the system by running shell commands and execute Python code.