### PR TITLE
Add Cartero

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@
 - [Turtle](https://gitlab.gnome.org/philippun1/turtle) - Tool to manage Git repositories within Nautilus by providing emblems and context menus.
 - [Aurea](https://flathub.org/apps/io.github.cleomenezesjr.aurea) - Simple preview banner made to read metainfo files from Flatpak apps and represent them as they would on Flathub.
 - [Exhibit](https://flathub.org/apps/io.github.nokse22.Exhibit) - 3D model previewer based on the F3D library that supports many formats.
+- [Cartero](https://cartero.danirod.es) - Graphical HTTP client to perform HTTP requests and test web APIs.
 
 #### Design Tooling
 


### PR DESCRIPTION
Add [Cartero](https://cartero.danirod.es), a `libadwaita` graphical HTTP client to perform HTTP requests and test web APIs locally.