### PR TITLE
Add Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@
 - [Luminance](https://github.com/sidevesh/Luminance) - Simple application to control brightness of displays (including external) supporting DDC/CI.
 - [Bustle](https://flathub.org/apps/org.freedesktop.Bustle) - D-Bus activity viewer that draws diagram sequences.
 - [Embellish](https://flathub.org/apps/io.github.getnf.embellish) - Application to install and manage Nerd Fonts on the system.
+- [Resources](https://apps.gnome.org/Resources) - Monitor for system resources and processes that can terminate graphical applications and processes. ![GNOME Circle][GNOME Circle]
 
 ### Utilities
 


### PR DESCRIPTION
Add [Resources](https://apps.gnome.org/Resources), a system resources monitor recently introduced in GNOME Circle.