### PR TITLE
Add Tuba

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@
 - [Fractal](https://flathub.org/apps/org.gnome.Fractal) - Matrix client.
 - [Dino](https://dino.im) - XMPP Client.
 - [Dissent](https://flathub.org/apps/so.libdb.dissent) - Third-party Discord client prioritasing speed over feature completeness (with user theming through CSS).
+- [Tuba](https://apps.gnome.org/Tuba) - Client for federated social networks (Mastodon, GoToSocial, Akkoma).
 
 ### Office
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@
 - [Fractal](https://flathub.org/apps/org.gnome.Fractal) - Matrix client.
 - [Dino](https://dino.im) - XMPP Client.
 - [Dissent](https://flathub.org/apps/so.libdb.dissent) - Third-party Discord client prioritasing speed over feature completeness (with user theming through CSS).
-- [Tuba](https://apps.gnome.org/Tuba) - Client for federated social networks (Mastodon, GoToSocial, Akkoma).
+- [Tuba](https://apps.gnome.org/Tuba) - Client for federated social networks (Mastodon, GoToSocial, Akkoma). ![GNOME Circle][GNOME Circle]
 
 ### Office
 


### PR DESCRIPTION
Add [Tuba](https://apps.gnome.org/Tuba), a client for the Fediverse for the GNOME Desktop, recenlty added to GNOME Circle.