### PR TITLE
Add Dev Toolbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@
 - [Aurea](https://flathub.org/apps/io.github.cleomenezesjr.aurea) - Simple preview banner made to read metainfo files from Flatpak apps and represent them as they would on Flathub.
 - [Exhibit](https://flathub.org/apps/io.github.nokse22.Exhibit) - 3D model previewer based on the F3D library that supports many formats.
 - [Cartero](https://cartero.danirod.es) - Graphical HTTP client to perform HTTP requests and test web APIs.
-- [Dev Toolbox](https://flathub.org/apps/me.iepure.devtoolbox) - Toolbox for developpers providings converters, formatters, Regex/Cron testers, hash generators and more.
+- [Dev Toolbox](https://flathub.org/apps/me.iepure.devtoolbox) - Toolbox for developers providing converters, formatters, Regex/Cron testers, hash generators and more.
 
 #### Design Tooling
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@
 - [Aurea](https://flathub.org/apps/io.github.cleomenezesjr.aurea) - Simple preview banner made to read metainfo files from Flatpak apps and represent them as they would on Flathub.
 - [Exhibit](https://flathub.org/apps/io.github.nokse22.Exhibit) - 3D model previewer based on the F3D library that supports many formats.
 - [Cartero](https://cartero.danirod.es) - Graphical HTTP client to perform HTTP requests and test web APIs.
+- [Dev Toolbox](https://flathub.org/apps/me.iepure.devtoolbox) - Toolbox for developpers providings converters, formatters, Regex/Cron testers, hash generators and more.
 
 #### Design Tooling
 


### PR DESCRIPTION
Add [Dev Toolbox](https://flathub.org/apps/me.iepure.devtoolbox), a GTK 4 Adwaita Toolbox for developers providing multiple tools.