### PR TITLE
Add Drum Machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@
 - [Monophony](https://flathub.org/fr/apps/io.gitlab.zehkira.Monophony) - Stream music from YouTube.
 - [Collector](https://mijorus.it/projects/collector) - Dropover utility that allows to drag files/images/text into a collection window and drop them anywhere.
 - [Fotema](https://flathub.org/apps/app.fotema.Fotema) - Photo gallery with support for iOS Live Photos and Samsung Motion Photos and with map view.
+- [Drum Machine](https://apps.gnome.org/DrumMachine/) - Create and play drum beats. ![GNOME Circle][GNOME Circle]
 
 ### Graphics
 


### PR DESCRIPTION
This PR adds the Drum Machine app to the Multimedia category in the README.md.

Related links:  
- Source: https://github.com/Revisto/drum-machine  
- GNOME Apps: https://apps.gnome.org/DrumMachine/